### PR TITLE
Fix docker configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git*
+.env*
+docker-compose.yml
+Dockerfile
+LICENSE
+README.md
+bino

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.16-buster
 WORKDIR /app
-COPY main.go go.mod go.sum /app
+COPY . /app
 RUN go mod download && go build -o bino
 CMD ["./bino"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - BINO_DISCORD_TOKEN
     depends_on:
       - db
-    command: bash -c "go mod download && go build -o bino && ./bino"
+    command: bash -c "go build -o bino && ./bino"
   db:
     container_name: binodb
     image: mysql:8

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - BINO_DISCORD_TOKEN
     depends_on:
       - db
+    command: bash -c "go mod download && go build -o bino && ./bino"
   db:
     container_name: binodb
     image: mysql:8


### PR DESCRIPTION
Running the dockerized version of the app was broken cause it wouldn't include all required directories, only `main.go`, `go.sum` and `go.mod`.

I've included a `.dockerignore` to help managing it and also fixed the starting command on docker-compose.